### PR TITLE
Add Windows Start Menu & autostart workflows, tray output viewer, and notification plumbing

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A Windows-focused Python application that lets you define an ordered list of Wi-
 - TOML configuration
 - Rotating log file support
 - Optional system tray app
+- Start-menu shortcut installation helpers (launch, uninstall, enable startup)
 - Optional Windows Task Scheduler startup registration
 - Default config and logs stored in platform app-data directories
 - Live config reload while the service is running
@@ -46,7 +47,22 @@ poetry run polyfi-ranked --tray
 
 ```powershell
 poetry run polyfi-ranked-install-task
+
+# Or use the consolidated startup manager:
+poetry run polyfi-ranked-startup enable-autostart
 ```
+
+## Start Menu shortcuts
+
+```powershell
+poetry run polyfi-ranked-startup install-shortcuts
+```
+
+This installs a `PolyFi Ranked` Start Menu folder containing:
+
+- `PolyFi: Ranked` (tray launch, requests elevation if needed)
+- `Uninstall PolyFi: Ranked`
+- `Enable Start with Windows`
 
 ## Live config reload
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ pillow = "^11.1.0"
 [tool.poetry.scripts]
 polyfi-ranked = "wifi_pref_manager.app:main"
 polyfi-ranked-install-task = "wifi_pref_manager.scheduler:main"
+polyfi-ranked-startup = "wifi_pref_manager.startup:main"
 
 [build-system]
 requires = ["poetry-core>=1.8.0"]

--- a/src/wifi_pref_manager/app.py
+++ b/src/wifi_pref_manager/app.py
@@ -38,12 +38,15 @@ from __future__ import annotations
 
 import argparse
 import sys
+from tkinter import messagebox
+import tkinter as tk
 
 from wifi_pref_manager.config import ConfigError, ConfigLoader
 from wifi_pref_manager.logging_utils import configure_logging
 from wifi_pref_manager.netsh_wifi import NetshWiFiApi
 from wifi_pref_manager.paths import AppPaths
 from wifi_pref_manager.service import WiFiPreferenceService
+from wifi_pref_manager.startup import is_running_as_admin, relaunch_as_admin
 from wifi_pref_manager.ui.tray import TrayApplication
 
 
@@ -83,9 +86,19 @@ class Application:
             action='store_true',
             help='Print the default config and log paths, then exit.',
         )
+        parser.add_argument(
+            '--require-admin',
+            action='store_true',
+            help='Require administrator rights (used by start-menu shortcut).',
+        )
+        parser.add_argument(
+            '--show-console',
+            action='store_true',
+            help='Show live console output even in tray mode.',
+        )
         return parser
 
-    def on_config_reloaded(self, config) -> object:
+    def on_config_reloaded(self, config, include_console: bool) -> object:
         """
         Reconfigure logging when the config changes.
 
@@ -96,7 +109,17 @@ class Application:
         Returns:
             Refreshed logger instance.
         """
-        return configure_logging(config.log_level, config.log_file)
+        return configure_logging(config.log_level, config.log_file, include_console=include_console)
+
+    def _prompt_admin_restart(self) -> bool:
+        root = tk.Tk()
+        root.withdraw()
+        should_restart = messagebox.askyesno(
+            'Administrator permissions required',
+            'PolyFi needs administrator privileges when started from the Start menu. Restart as administrator now?',
+        )
+        root.destroy()
+        return should_restart
 
     def run(self, argv: list[str] | None = None) -> int:
         """
@@ -127,8 +150,16 @@ class Application:
             print(f'Config path: {config_path}', file=sys.stderr)
             return 1
 
-        logger = configure_logging(config.log_level, config.log_file)
+        tray_mode = args.tray or config.start_minimized_to_tray
+        include_console = args.show_console or not tray_mode
+        logger = configure_logging(config.log_level, config.log_file, include_console=include_console)
         logger.info('Using config file: %s', config_path)
+
+        if args.require_admin and not is_running_as_admin():
+            logger.warning('Start-menu launch detected without administrator rights.')
+            if self._prompt_admin_restart() and relaunch_as_admin(sys.argv):
+                return 0
+            return 1
 
         wifi_api = NetshWiFiApi(logger=logger)
         service = WiFiPreferenceService(
@@ -136,10 +167,10 @@ class Application:
             wifi_api=wifi_api,
             logger=logger,
             config_loader=loader,
-            on_config_reloaded=self.on_config_reloaded,
+            on_config_reloaded=lambda updated_config: self.on_config_reloaded(updated_config, include_console=include_console),
         )
 
-        if args.tray or config.start_minimized_to_tray:
+        if tray_mode:
             tray_app = TrayApplication(service=service, logger=logger, config_loader=loader)
             tray_app.run()
             return 0

--- a/src/wifi_pref_manager/config.py
+++ b/src/wifi_pref_manager/config.py
@@ -48,6 +48,7 @@ log_file = ''
 interface_name = ''
 start_minimized_to_tray = false
 auto_disable_wifi_on_ethernet = true
+show_close_window_hint = true
 
 [[networks]]
 ssid = 'MyBestWiFi'
@@ -186,6 +187,7 @@ class ConfigLoader:
             log_file=log_file,
             start_minimized_to_tray=bool(general.get('start_minimized_to_tray', False)),
             auto_disable_wifi_on_ethernet=bool(general.get('auto_disable_wifi_on_ethernet', True)),
+            show_close_window_hint=bool(general.get('show_close_window_hint', True)),
         )
         self.mark_loaded()
         return config
@@ -219,6 +221,7 @@ def save_config(config: AppConfig, config_path: Path) -> None:
         f'interface_name = {_str(config.interface_name or "")}\n',
         f'start_minimized_to_tray = {_bool(config.start_minimized_to_tray)}\n',
         f'auto_disable_wifi_on_ethernet = {_bool(config.auto_disable_wifi_on_ethernet)}\n',
+        f'show_close_window_hint = {_bool(config.show_close_window_hint)}\n',
     ]
 
     for network in config.preferred_networks:

--- a/src/wifi_pref_manager/logging_utils.py
+++ b/src/wifi_pref_manager/logging_utils.py
@@ -38,7 +38,7 @@ from pathlib import Path
 LOGGER_NAME = 'polyfi_ranked'
 
 
-def configure_logging(log_level: str, log_file: str) -> logging.Logger:
+def configure_logging(log_level: str, log_file: str, *, include_console: bool = True) -> logging.Logger:
     """
     Configure and return the shared application logger.
 
@@ -61,8 +61,10 @@ def configure_logging(log_level: str, log_file: str) -> logging.Logger:
         fmt='%(asctime)s | %(levelname)s | %(name)s | %(message)s',
     )
 
-    console_handler = logging.StreamHandler()
-    console_handler.setFormatter(formatter)
+    if include_console:
+        console_handler = logging.StreamHandler()
+        console_handler.setFormatter(formatter)
+        logger.addHandler(console_handler)
 
     file_handler = RotatingFileHandler(
         Path(log_file).expanduser().resolve(),
@@ -72,7 +74,6 @@ def configure_logging(log_level: str, log_file: str) -> logging.Logger:
     )
     file_handler.setFormatter(formatter)
 
-    logger.addHandler(console_handler)
     logger.addHandler(file_handler)
     logger.propagate = False
     return logger

--- a/src/wifi_pref_manager/models.py
+++ b/src/wifi_pref_manager/models.py
@@ -82,3 +82,4 @@ class AppConfig:
     log_file: str = ''
     start_minimized_to_tray: bool = False
     auto_disable_wifi_on_ethernet: bool = True
+    show_close_window_hint: bool = True

--- a/src/wifi_pref_manager/scheduler.py
+++ b/src/wifi_pref_manager/scheduler.py
@@ -72,6 +72,18 @@ class TaskSchedulerInstaller:
         subprocess.run(command, check=True)
         print(f'Installed scheduled task: {TASK_NAME}')
 
+    def uninstall(self) -> None:
+        """Delete the scheduled task if it exists."""
+        command = [
+            'schtasks',
+            '/Delete',
+            '/F',
+            '/TN',
+            TASK_NAME,
+        ]
+        subprocess.run(command, check=False)
+        print(f'Removed scheduled task: {TASK_NAME}')
+
 
 def main() -> int:
     """

--- a/src/wifi_pref_manager/service.py
+++ b/src/wifi_pref_manager/service.py
@@ -66,6 +66,7 @@ class WiFiPreferenceService:
         logger: logging.Logger,
         config_loader: ConfigLoader | None = None,
         on_config_reloaded: Callable[[AppConfig], logging.Logger] | None = None,
+        on_notify: Callable[[str, str], None] | None = None,
     ) -> None:
         """
         Parameters:
@@ -85,9 +86,11 @@ class WiFiPreferenceService:
         self.logger = logger
         self.config_loader = config_loader
         self.on_config_reloaded = on_config_reloaded
+        self.on_notify = on_notify
         self._stop_event = threading.Event()
         self._thread: threading.Thread | None = None
         self._wifi_disabled_by_ethernet: bool = False
+        self._ethernet_notified: bool = False
 
         if not self.config.interface_name:
             self.config.interface_name = self.wifi_api.detect_wifi_interface()
@@ -202,32 +205,43 @@ class WiFiPreferenceService:
         """
         if self.config.auto_disable_wifi_on_ethernet:
             ethernet_active = self.wifi_api.is_ethernet_connected(self.interface_name)
-            self.logger.debug('Ethernet connection check: ethernet_active=%s, _wifi_disabled_by_ethernet=%s',
-                            ethernet_active, self._wifi_disabled_by_ethernet)
-            
+            self.logger.debug(
+                'Ethernet connection check: ethernet_active=%s, _wifi_disabled_by_ethernet=%s',
+                ethernet_active,
+                self._wifi_disabled_by_ethernet,
+            )
+
             if ethernet_active:
-                # Ethernet is connected - disable WiFi adapter completely
+                if not self._ethernet_notified:
+                    self._notify(
+                        'Ethernet detected',
+                        'Ethernet is active. Wi-Fi will be disabled unless you turn off auto-disable in settings.',
+                    )
+                    self._ethernet_notified = True
+
                 if not self._wifi_disabled_by_ethernet:
                     self.logger.info('Ethernet connection detected. Disabling Wi-Fi adapter completely.')
                     try:
                         self.wifi_api.disable_wifi_adapter(self.interface_name)
                         self._wifi_disabled_by_ethernet = True
+                        self._notify(
+                            'Wi-Fi disabled',
+                            'Wi-Fi interface was disabled because Ethernet is connected.',
+                        )
                     except NetshError as exc:
                         self.logger.error('Failed to disable Wi-Fi adapter: %s', exc)
                 return
-            else:
-                # Ethernet is not connected - re-enable WiFi if it was disabled
-                if self._wifi_disabled_by_ethernet:
-                    self.logger.info('Ethernet disconnected. Re-enabling Wi-Fi adapter.')
-                    try:
-                        self.wifi_api.enable_wifi_adapter(self.interface_name)
-                        self._wifi_disabled_by_ethernet = False
-                        # Give the adapter a moment to come back up
-                        time.sleep(2)
-                    except NetshError as exc:
-                        self.logger.error('Failed to re-enable Wi-Fi adapter: %s', exc)
-                        # Clear the flag anyway to avoid getting stuck
-                        self._wifi_disabled_by_ethernet = False
+
+            self._ethernet_notified = False
+            if self._wifi_disabled_by_ethernet:
+                self.logger.info('Ethernet disconnected. Re-enabling Wi-Fi adapter.')
+                try:
+                    self.wifi_api.enable_wifi_adapter(self.interface_name)
+                    self._wifi_disabled_by_ethernet = False
+                    time.sleep(2)
+                except NetshError as exc:
+                    self.logger.error('Failed to re-enable Wi-Fi adapter: %s', exc)
+                    self._wifi_disabled_by_ethernet = False
 
         current_ssid = self.wifi_api.get_current_ssid()
         visible_ssids = self.wifi_api.get_visible_ssids()
@@ -268,6 +282,15 @@ class WiFiPreferenceService:
                 self.logger.info('Connected to %r', best_available)
             else:
                 self.logger.warning('Connection attempt to %r could not be confirmed.', best_available)
+
+    def _notify(self, title: str, message: str) -> None:
+        """Send a user notification when a callback is configured."""
+        if self.on_notify is None:
+            return
+        try:
+            self.on_notify(title, message)
+        except Exception:  # noqa: BLE001
+            self.logger.debug('Failed to send UI notification.', exc_info=True)
 
     def run_forever(self) -> None:
         """

--- a/src/wifi_pref_manager/startup.py
+++ b/src/wifi_pref_manager/startup.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import argparse
+import ctypes
+import subprocess
+import sys
+from pathlib import Path
+
+from wifi_pref_manager.scheduler import TaskSchedulerInstaller
+
+APP_NAME = 'PolyFi: Ranked'
+START_MENU_FOLDER = 'PolyFi Ranked'
+
+
+class StartupManager:
+    def __init__(self) -> None:
+        self.python_executable = Path(sys.executable)
+
+    @property
+    def pythonw_executable(self) -> Path:
+        candidate = self.python_executable.with_name('pythonw.exe')
+        return candidate if candidate.exists() else self.python_executable
+
+    def create_start_menu_shortcuts(self) -> None:
+        command = (
+            "$shell = New-Object -ComObject WScript.Shell;"
+            '$folder = Join-Path $env:APPDATA "Microsoft\\Windows\\Start Menu\\Programs\\' + START_MENU_FOLDER + '";'
+            'New-Item -ItemType Directory -Path $folder -Force | Out-Null;'
+            '$shortcuts = @('
+            f"@{{Name='{APP_NAME}';Args='-m wifi_pref_manager.app --tray --require-admin';Target='{self.pythonw_executable}'}},"
+            f"@{{Name='Uninstall {APP_NAME}';Args='-m wifi_pref_manager.startup uninstall';Target='{self.python_executable}'}},"
+            f"@{{Name='Enable Start with Windows';Args='-m wifi_pref_manager.startup enable-autostart';Target='{self.python_executable}'}}"
+            ');'
+            'foreach ($entry in $shortcuts) {'
+            '$path = Join-Path $folder ($entry.Name + ".lnk");'
+            '$shortcut = $shell.CreateShortcut($path);'
+            '$shortcut.TargetPath = $entry.Target;'
+            '$shortcut.Arguments = $entry.Args;'
+            '$shortcut.WorkingDirectory = [System.IO.Path]::GetDirectoryName($entry.Target);'
+            '$shortcut.Save();'
+            '}'
+        )
+        self._run_powershell(command)
+
+    def remove_start_menu_shortcuts(self) -> None:
+        command = (
+            '$folder = Join-Path $env:APPDATA "Microsoft\\Windows\\Start Menu\\Programs\\' + START_MENU_FOLDER + '";'
+            'if (Test-Path $folder) { Remove-Item -Path $folder -Recurse -Force }'
+        )
+        self._run_powershell(command)
+
+    def _run_powershell(self, command: str) -> None:
+        subprocess.run(
+            ['powershell', '-NoProfile', '-NonInteractive', '-Command', command],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+
+def is_running_as_admin() -> bool:
+    try:
+        return bool(ctypes.windll.shell32.IsUserAnAdmin())
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def relaunch_as_admin(argv: list[str]) -> bool:
+    params = ' '.join(f'"{arg}"' for arg in argv)
+    try:
+        result = ctypes.windll.shell32.ShellExecuteW(None, 'runas', sys.executable, params, None, 1)
+    except Exception:  # noqa: BLE001
+        return False
+    return int(result) > 32
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description='Manage PolyFi start-menu and startup behavior.')
+    parser.add_argument('command', choices=['install-shortcuts', 'remove-shortcuts', 'enable-autostart', 'disable-autostart', 'uninstall'])
+    args = parser.parse_args()
+
+    startup_manager = StartupManager()
+    task_installer = TaskSchedulerInstaller(python_executable=str(startup_manager.pythonw_executable))
+
+    if args.command == 'install-shortcuts':
+        startup_manager.create_start_menu_shortcuts()
+        print('Installed start-menu shortcuts.')
+        return 0
+    if args.command == 'remove-shortcuts':
+        startup_manager.remove_start_menu_shortcuts()
+        print('Removed start-menu shortcuts.')
+        return 0
+    if args.command == 'enable-autostart':
+        task_installer.install()
+        print('Enabled start with Windows.')
+        return 0
+    if args.command == 'disable-autostart':
+        task_installer.uninstall()
+        print('Disabled start with Windows.')
+        return 0
+
+    task_installer.uninstall()
+    startup_manager.remove_start_menu_shortcuts()
+    print('PolyFi startup artifacts removed.')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/src/wifi_pref_manager/ui/log_viewer.py
+++ b/src/wifi_pref_manager/ui/log_viewer.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import logging
+import threading
+import tkinter as tk
+from collections.abc import Callable
+from tkinter import ttk
+
+from wifi_pref_manager.config import save_config
+from wifi_pref_manager.service import WiFiPreferenceService
+
+
+class LogHistoryHandler(logging.Handler):
+    """In-memory log sink that can stream lines to listeners."""
+
+    def __init__(self, max_lines: int = 2000) -> None:
+        super().__init__()
+        self.max_lines = max_lines
+        self._lines: list[str] = []
+        self._listeners: list[Callable[[str], None]] = []
+        self._lock = threading.Lock()
+
+    def emit(self, record: logging.LogRecord) -> None:
+        line = self.format(record)
+        with self._lock:
+            self._lines.append(line)
+            if len(self._lines) > self.max_lines:
+                self._lines = self._lines[-self.max_lines:]
+            listeners = list(self._listeners)
+        for listener in listeners:
+            listener(line)
+
+    def get_lines(self) -> list[str]:
+        with self._lock:
+            return list(self._lines)
+
+    def add_listener(self, listener) -> None:
+        with self._lock:
+            self._listeners.append(listener)
+
+    def remove_listener(self, listener) -> None:
+        with self._lock:
+            self._listeners = [entry for entry in self._listeners if entry != listener]
+
+
+class LogViewerWindow:
+    """Tk-based log history and live-output window."""
+
+    def __init__(
+        self,
+        service: WiFiPreferenceService,
+        config_loader,
+        logger: logging.Logger,
+        log_handler: LogHistoryHandler,
+    ) -> None:
+        self.service = service
+        self.config_loader = config_loader
+        self.logger = logger
+        self.log_handler = log_handler
+        self._window: tk.Toplevel | None = None
+        self._text: tk.Text | None = None
+        self._open_lock = threading.Lock()
+
+    def open(self) -> None:
+        if not self._open_lock.acquire(blocking=False):
+            return
+        try:
+            if self._window is not None and self._window.winfo_exists():
+                self._window.lift()
+                self._window.focus_force()
+                return
+            self._build_window()
+        finally:
+            self._open_lock.release()
+
+    def _build_window(self) -> None:
+        root = tk.Tk()
+        root.withdraw()
+
+        win = tk.Toplevel(root)
+        win.title('PolyFi: Ranked - Output')
+        win.geometry('900x480')
+        win.protocol('WM_DELETE_WINDOW', lambda: self._on_close(win, root))
+        self._window = win
+
+        text = tk.Text(win, wrap='none')
+        text.grid(row=0, column=0, sticky='nsew')
+        self._text = text
+
+        scroll_y = ttk.Scrollbar(win, orient='vertical', command=text.yview)
+        scroll_y.grid(row=0, column=1, sticky='ns')
+        text.configure(yscrollcommand=scroll_y.set)
+
+        win.columnconfigure(0, weight=1)
+        win.rowconfigure(0, weight=1)
+
+        for line in self.log_handler.get_lines():
+            text.insert('end', line + '\n')
+        text.see('end')
+
+        def _on_log_line(line: str) -> None:
+            if self._text is None:
+                return
+            self._text.after(0, lambda: self._append_line(line))
+
+        self.log_handler.add_listener(_on_log_line)
+
+        def _cleanup() -> None:
+            self.log_handler.remove_listener(_on_log_line)
+            self._text = None
+            self._window = None
+
+        win.bind('<Destroy>', lambda _event: _cleanup())
+        win.mainloop()
+
+    def _append_line(self, line: str) -> None:
+        if self._text is None:
+            return
+        self._text.insert('end', line + '\n')
+        self._text.see('end')
+
+    def _on_close(self, win: tk.Toplevel, root: tk.Tk) -> None:
+        config = self.service.config
+        if config.show_close_window_hint:
+            answer = self._show_close_message_dialog(win)
+            if answer == 'cancel':
+                return
+            if answer == 'dont_tell_again':
+                config.show_close_window_hint = False
+                save_config(config, self.config_loader.config_path)
+                self.config_loader.mark_loaded()
+            if answer == 'exit_app':
+                self.service.stop()
+                root.quit()
+                win.destroy()
+                root.destroy()
+                return
+
+        win.destroy()
+        root.destroy()
+
+    def _show_close_message_dialog(self, parent: tk.Toplevel) -> str:
+        dialog = tk.Toplevel(parent)
+        dialog.title('Window behavior')
+        dialog.transient(parent)
+        dialog.grab_set()
+        dialog.resizable(False, False)
+
+        ttk.Label(
+            dialog,
+            text='Closing the output window will keep PolyFi running in the tray.',
+            wraplength=420,
+            justify='left',
+        ).grid(row=0, column=0, columnspan=2, padx=12, pady=(12, 8), sticky='w')
+
+        dont_show_var = tk.BooleanVar(value=False)
+        ttk.Checkbutton(
+            dialog,
+            text="Don't tell me this again",
+            variable=dont_show_var,
+        ).grid(row=1, column=0, columnspan=2, padx=12, pady=(0, 8), sticky='w')
+
+        result = {'value': 'close_window'}
+
+        def _close_window() -> None:
+            result['value'] = 'dont_tell_again' if dont_show_var.get() else 'close_window'
+            dialog.destroy()
+
+        def _exit_app() -> None:
+            result['value'] = 'exit_app'
+            dialog.destroy()
+
+        ttk.Button(dialog, text='Keep Running', command=_close_window, width=14).grid(
+            row=2, column=0, padx=(12, 4), pady=(0, 12), sticky='e'
+        )
+        ttk.Button(dialog, text='Well it Should', command=_exit_app, width=14).grid(
+            row=2, column=1, padx=(4, 12), pady=(0, 12), sticky='w'
+        )
+
+        dialog.wait_window()
+        return result['value']

--- a/src/wifi_pref_manager/ui/settings.py
+++ b/src/wifi_pref_manager/ui/settings.py
@@ -214,11 +214,17 @@ class SettingsWindow:
         frame_opts.grid(row=1, column=0, padx=10, pady=4, sticky='ew')
 
         auto_eth_var = tk.BooleanVar(value=config.auto_disable_wifi_on_ethernet)
+        close_hint_var = tk.BooleanVar(value=config.show_close_window_hint)
         ttk.Checkbutton(
             frame_opts,
             text='Automatically disconnect Wi-Fi when Ethernet is connected',
             variable=auto_eth_var,
         ).grid(row=0, column=0, sticky='w')
+        ttk.Checkbutton(
+            frame_opts,
+            text='Show reminder when closing the output window',
+            variable=close_hint_var,
+        ).grid(row=1, column=0, sticky='w')
 
         # ---- Action buttons --------------------------------------------
         frame_btns = ttk.Frame(win)
@@ -243,6 +249,7 @@ class SettingsWindow:
                 log_file=config.log_file,
                 start_minimized_to_tray=config.start_minimized_to_tray,
                 auto_disable_wifi_on_ethernet=auto_eth_var.get(),
+                show_close_window_hint=close_hint_var.get(),
             )
 
             try:

--- a/src/wifi_pref_manager/ui/tray.py
+++ b/src/wifi_pref_manager/ui/tray.py
@@ -31,6 +31,8 @@ Example Usage:
 from __future__ import annotations
 
 import logging
+import subprocess
+import sys
 import threading
 from typing import TYPE_CHECKING
 
@@ -38,6 +40,7 @@ from PIL import Image, ImageDraw
 import pystray
 
 from wifi_pref_manager.service import WiFiPreferenceService
+from wifi_pref_manager.ui.log_viewer import LogHistoryHandler, LogViewerWindow
 
 if TYPE_CHECKING:
     from wifi_pref_manager.ui.settings import SettingsWindow
@@ -63,6 +66,10 @@ class TrayApplication:
         self.config_loader = config_loader
         self.icon: pystray.Icon | None = None
         self._settings_window: SettingsWindow | None = None
+        self._log_window: LogViewerWindow | None = None
+        self.log_handler = LogHistoryHandler()
+        self.log_handler.setFormatter(logging.Formatter('%(asctime)s | %(levelname)s | %(name)s | %(message)s'))
+        self.logger.addHandler(self.log_handler)
 
     def create_image(self) -> Image.Image:
         """
@@ -114,21 +121,53 @@ class TrayApplication:
         self.service.stop()
         icon.stop()
 
+    def on_show_output(self, icon: pystray.Icon, item: pystray.MenuItem) -> None:
+        del icon, item
+        if self._log_window is None:
+            self._log_window = LogViewerWindow(
+                service=self.service,
+                config_loader=self.config_loader,
+                logger=self.logger,
+                log_handler=self.log_handler,
+            )
+        thread = threading.Thread(target=self._log_window.open, daemon=True)
+        thread.start()
+
+    def on_notify(self, title: str, message: str) -> None:
+        if self.icon is None:
+            return
+        try:
+            self.icon.notify(message, title=title)
+        except Exception:  # noqa: BLE001
+            self.logger.debug('Failed to show tray notification.', exc_info=True)
+
+    def on_install_start_menu(self, icon: pystray.Icon, item: pystray.MenuItem) -> None:
+        del icon, item
+        subprocess.run([sys.executable, '-m', 'wifi_pref_manager.startup', 'install-shortcuts'], check=False)
+
+    def on_enable_startup(self, icon: pystray.Icon, item: pystray.MenuItem) -> None:
+        del icon, item
+        subprocess.run([sys.executable, '-m', 'wifi_pref_manager.startup', 'enable-autostart'], check=False)
+
     def run(self) -> None:
         """
         Start the service and tray icon loop.
         """
         self.service.start()
+        self.service.on_notify = self.on_notify
         self.icon = pystray.Icon(
             'polyfi_ranked',
             self.create_image(),
             'PolyFi: Ranked',
             menu=pystray.Menu(
                 pystray.MenuItem('Manage Networks…', self.on_manage_networks),
+                pystray.MenuItem('Show Output…', self.on_show_output),
                 pystray.MenuItem('Rescan Now', self.on_rescan),
+                pystray.Menu.SEPARATOR,
+                pystray.MenuItem('Install Start Menu Shortcuts', self.on_install_start_menu),
+                pystray.MenuItem('Enable Start With Windows', self.on_enable_startup),
                 pystray.Menu.SEPARATOR,
                 pystray.MenuItem('Quit', self.on_quit),
             ),
         )
         self.icon.run()
-


### PR DESCRIPTION
### Motivation
- Provide a convenient Start Menu folder with install/uninstall/startup shortcuts and an easier way to enable autostart. 
- Avoid an always-visible console when running as a tray app while retaining an opt-in live output window. 
- Surface important events (Ethernet detected / Wi‑Fi disabled) to users via tray notifications and give users control over output-window close behavior.

### Description
- Added a new `wifi_pref_manager.startup` module to create/remove Start Menu shortcuts and to provide consolidated install/uninstall/autostart commands, plus a `polyfi-ranked-startup` entry point. 
- Implemented admin-launch flow in the main app with `--require-admin` (prompt + relaunch elevation) and `--show-console` to override suppressed console output in tray mode, and made console logging optional via `configure_logging(..., include_console=...)`. 
- Added tray UX: new menu items to `Install Start Menu Shortcuts`, `Enable Start With Windows`, and `Show Output…`, wired to a new in-memory `LogHistoryHandler` and `LogViewerWindow` that shows history and live output and does not exit the service when closed by default. 
- Added service notification plumbing (`on_notify`) and service-side notifications for Ethernet detection and Wi‑Fi adapter disable/enable events. 
- Extended configuration (`AppConfig`) and TOML save/load with `show_close_window_hint` and exposed a settings checkbox to persist the output-window reminder preference. 
- Added scheduled task uninstall support in `TaskSchedulerInstaller` and updated README and Poetry scripts to document new startup commands.

### Testing
- Compiled the package modules with `python -m compileall src` and compilation completed successfully. 
- Ran the new startup CLI help with `PYTHONPATH=src python -m wifi_pref_manager.startup --help` and it printed usage (succeeded). 
- No Windows GUI/notification end-to-end tests were run in this Linux container, so tray notifications, Start Menu shortcut creation, scheduled task behavior, and elevation flow were not exercised here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfdbff56a8832db7060dae3aa4c701)

## Summary by Sourcery

Add Windows startup management, tray output viewing, and notification capabilities to the PolyFi Ranked app.

New Features:
- Introduce a startup manager CLI and entry point for installing/removing Start Menu shortcuts and configuring Windows autostart.
- Add a tray log viewer window with live log streaming and history, accessible via a new 'Show Output…' tray menu item.
- Provide tray menu actions to install Start Menu shortcuts and enable starting with Windows.
- Support optional console-less logging when running in tray mode, with a flag to force showing the console.
- Add user notifications for Ethernet detection and Wi‑Fi adapter disable/enable events via a service callback hook.
- Expose a user setting to control whether a reminder is shown when closing the output window.

Enhancements:
- Refine Ethernet/Wi‑Fi auto-disable logic to avoid repeated notifications and ensure Wi‑Fi is re-enabled when Ethernet disconnects.
- Extend the scheduled task installer with an uninstall operation used by the startup manager.
- Wire the tray application to receive service notifications and surface them as system tray toasts.
- Extend configuration models and TOML serialization to persist the new output-window preference.
- Update README to document new startup commands and Start Menu shortcut helpers.
- Make logging configuration support enabling/disabling console output based on tray mode.

Build:
- Add a new Poetry console script entry point for the startup manager CLI.

Documentation:
- Expand README with instructions for using the startup manager CLI and installing Start Menu shortcuts.