### PR TITLE
docs/fix: fix MyST cross-reference targets in CLI reference and Ethernet adapter exclusion bug

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -52,7 +52,7 @@ body:
     id: version
     attributes:
       label: "PolyFi: Ranked version"
-      placeholder: "e.g. 1.0.0-dev.11"
+      placeholder: "e.g. 1.0.0-dev.16"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,22 @@ versions so packaging, docs, and support paths stay aligned.
 
 - Placeholder for upcoming changes.
 
+## [1.0.0-dev.16] - 2026-05-28
+
+### Changed
+
+- Reduced steady-state tray overhead by using the lighter `netsh interface`
+  path for routine Ethernet checks, skipping visible-network scans while the
+  current Wi-Fi network is already the highest actionable preference, and
+  slowing idle Tk dialog queue polling.
+
+### Fixed
+
+- Automatic speed tests configured for new connections no longer run just
+  because PolyFi starts while Windows is already connected; they now wait for
+  an actual observed connection change, an app-initiated connection change, or
+  the configured periodic interval.
+
 ## [1.0.0-dev.15] - 2026-05-28
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # PolyFi: Ranked
 
+[![CI](https://github.com/Inspyre-Softworks/PolyFi-Ranked/actions/workflows/ci.yml/badge.svg)](https://github.com/Inspyre-Softworks/PolyFi-Ranked/actions/workflows/ci.yml)
+[![Release Hygiene](https://github.com/Inspyre-Softworks/PolyFi-Ranked/actions/workflows/release-hygiene.yml/badge.svg)](https://github.com/Inspyre-Softworks/PolyFi-Ranked/actions/workflows/release-hygiene.yml)
+[![Documentation Status](https://readthedocs.org/projects/polyfi-ranked/badge/?version=latest)](https://polyfi-ranked.readthedocs.io/en/latest/)
+[![PyPI version](https://img.shields.io/pypi/v/polyfi-ranked.svg)](https://pypi.org/project/polyfi-ranked/)
+[![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/downloads/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Platform: Windows](https://img.shields.io/badge/platform-Windows-0078D4.svg?logo=windows)](https://www.microsoft.com/windows)
+
 A Windows-focused Python application that lets you define an ordered list of Wi-Fi networks and automatically connects to the highest-priority available network.
 
 ## Features

--- a/docs/wiki/Command-Line-Interface-(CLI)-Reference.md
+++ b/docs/wiki/Command-Line-Interface-(CLI)-Reference.md
@@ -1,4 +1,4 @@
-<a id="polyfi-ranked-cli-reference"></a>
+(polyfi-ranked-cli-reference)=
 
 # CLI Reference
 
@@ -27,7 +27,7 @@ PolyFi: Ranked provides command-line tools for launching the app, inspecting res
 
 ---
 
-<a id="quick-start"></a>
+(quick-start)=
 
 ## Quick Start
 
@@ -68,7 +68,7 @@ poetry run polyfi-ranked
 
 ---
 
-<a id="top-level-flags"></a>
+(top-level-flags)=
 
 ## Top-Level Flags
 
@@ -100,7 +100,7 @@ CRITICAL
 
 ---
 
-<a id="paths"></a>
+(paths)=
 
 ## `paths`
 
@@ -127,7 +127,7 @@ Examples include checking:
 
 ---
 
-<a id="config"></a>
+(config)=
 
 ## `config`
 
@@ -135,7 +135,7 @@ The `config` command group manages PolyFi: Ranked configuration files.
 
 ---
 
-<a id="config-init"></a>
+(config-init)=
 
 ## `config init`
 
@@ -165,7 +165,7 @@ polyfi-ranked config init --config C:\path\to\config.toml --force
 
 ---
 
-<a id="windows"></a>
+(windows)=
 
 ## `windows`
 
@@ -182,7 +182,7 @@ This includes:
 
 ---
 
-<a id="windows-start-menu-install"></a>
+(windows-start-menu-install)=
 
 ## `windows start-menu install`
 
@@ -200,7 +200,7 @@ After installation, PolyFi: Ranked should appear in the Windows Start Menu.
 
 ---
 
-<a id="windows-startup-install"></a>
+(windows-startup-install)=
 
 ## `windows startup install`
 
@@ -218,7 +218,7 @@ PolyFi: Ranked will start automatically on user login.
 
 ---
 
-<a id="windows-uninstall"></a>
+(windows-uninstall)=
 
 ## `windows uninstall`
 
@@ -242,7 +242,7 @@ polyfi-ranked windows uninstall --purge-data
 
 ---
 
-<a id="task-scheduler-entry-points"></a>
+(task-scheduler-entry-points)=
 
 ## Task Scheduler Entry Points
 
@@ -252,7 +252,7 @@ This is mainly useful when you want to manage the scheduled logon task directly.
 
 ---
 
-<a id="polyfi-ranked-install-task"></a>
+(polyfi-ranked-install-task)=
 
 ## `polyfi-ranked-install-task`
 
@@ -272,7 +272,8 @@ polyfi-ranked-install-task --uninstall
 
 ---
 
-<a id="reference-links"></a>
+(reference-links)=
+
 ## Reference Links
 
 Use these links to jump to sections on this page.

--- a/poetry.lock
+++ b/poetry.lock
@@ -1163,6 +1163,27 @@ dev = ["abi3audit", "black", "check-manifest", "coverage", "packaging", "pylint"
 test = ["pytest", "pytest-xdist", "setuptools"]
 
 [[package]]
+name = "py-spy"
+version = "0.4.2"
+description = ""
+optional = false
+python-versions = "*"
+groups = ["dev"]
+files = [
+    {file = "py_spy-0.4.2-py2.py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:1ccf688393105111684435f035bc14ec3f22117dd2b85b2414612cf27a22755a"},
+    {file = "py_spy-0.4.2-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:a0e6f6810ccf0fc5e64e85e0182a5b626c4496eec01b14fb8755154b363a4831"},
+    {file = "py_spy-0.4.2-py2.py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:142887e984a4e541071c99a4401ff8c3770f255d329dbd0f64e8c1dd51882cce"},
+    {file = "py_spy-0.4.2-py2.py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7f1c6d9b0e2379ead5bf792df43f4cf36153aa79e6dda4fb8ac7740cf8017110"},
+    {file = "py_spy-0.4.2-py2.py3-none-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:24720573f95230653b457671a1dcc3c5a381fcf4e92677761e328a430ad251b2"},
+    {file = "py_spy-0.4.2-py2.py3-none-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:aeb0323409199c785f730645e9f4bb7a7b9ca2c481f2c331a55642b5d13fa52f"},
+    {file = "py_spy-0.4.2-py2.py3-none-win_amd64.whl", hash = "sha256:8b06a353c177677e4e1701b288d8c58e2f8d4208ee81a8048d9f72ba800918f8"},
+    {file = "py_spy-0.4.2.tar.gz", hash = "sha256:90e600b27bb6bb40479637baca5a5b4bc2ba3395c93d889e672315d93042c4ae"},
+]
+
+[package.extras]
+test = ["numpy"]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 description = "Pygments is a syntax highlighting package written in Python."
@@ -2008,4 +2029,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "704260a35ef2467dc15aba96cae73726fb3bcbb2a92065fde642d80595a066bc"
+content-hash = "aba233cde29c8180a7c03a1a12dddcb298c9c0495e293ada6c8804f9ea736355"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "polyfi-ranked"
-version = "1.0.0-dev.15"
+version = "1.0.0-dev.16"
 description = "Windows Wi-Fi preference manager that auto-switches to the highest-priority available network."
 authors = ["Inspyre Softworks"]
 readme = "README.md"
@@ -24,6 +24,7 @@ platformdirs = "^4.9.4"
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.4.2"
 pytest-cov = "^7.0.0"
+py-spy = "^0.4.2"
 
 [tool.poetry.group.docs.dependencies]
 sphinx = ">=7.4,<9.0"

--- a/src/wifi_pref_manager/__init__.py
+++ b/src/wifi_pref_manager/__init__.py
@@ -1,4 +1,4 @@
 """PolyFi: Ranked package."""
 
 __all__ = ['__version__']
-__version__ = '1.0.0-dev.15'
+__version__ = '1.0.0-dev.16'

--- a/src/wifi_pref_manager/netsh_wifi.py
+++ b/src/wifi_pref_manager/netsh_wifi.py
@@ -679,35 +679,21 @@ class NetshWiFiApi:
             List of interface names that look like real, active Ethernet links.
         """
         try:
-            output = self._run_powershell(
-                '$adapters = Get-NetAdapter -Physical | Where-Object {'
-                ' $_.InterfaceType -eq 6'
-                ' -and $_.Status -eq "Up"'
-                ' -and $_.MediaConnectionState -eq "Connected"'
-                ' -and $_.PhysicalMediaType -eq "802.3"'
-                ' -and $_.ComponentID -ne "*msloop"'
-                ' } | Select-Object Name, InterfaceDescription;'
-                ' if ($adapters) { $adapters | ConvertTo-Json -Compress } else { "[]" }'
-            )
-            parsed = json.loads(output or '[]')
-            adapters = parsed if isinstance(parsed, list) else [parsed]
-            names = [
-                str(adapter.get('Name', '')).strip()
-                for adapter in adapters
-                if self._is_probable_ethernet_name(str(adapter.get('Name', '')))
-                and self._is_probable_ethernet_name(str(adapter.get('InterfaceDescription', '')))
-            ]
+            return self._get_active_ethernet_interfaces_netsh_strict(wifi_interface_name)
+        except NetshError:
             self.logger.debug(
-                'PowerShell Ethernet candidates: %s',
-                ', '.join(names) if names else '[none]',
-            )
-            return names
-        except (json.JSONDecodeError, OSError, subprocess.SubprocessError):
-            self.logger.debug(
-                'PowerShell Ethernet detection unavailable; falling back to netsh.',
+                'Netsh Ethernet detection unavailable; falling back to PowerShell.',
                 exc_info=True,
             )
-            return self._get_active_ethernet_interfaces_netsh(wifi_interface_name)
+
+        try:
+            return self._get_active_ethernet_interfaces_powershell()
+        except (json.JSONDecodeError, OSError, subprocess.SubprocessError):
+            self.logger.debug(
+                'PowerShell Ethernet detection unavailable.',
+                exc_info=True,
+            )
+            return []
 
     def is_ethernet_connected(self, wifi_interface_name: str | None = None) -> bool:
         """
@@ -731,9 +717,44 @@ class NetshWiFiApi:
         """
         return bool(self.get_active_ethernet_interfaces(wifi_interface_name))
 
-    def _get_active_ethernet_interfaces_netsh(self, wifi_interface_name: str | None = None) -> list[str]:
+    def _get_active_ethernet_interfaces_powershell(self) -> list[str]:
         """
-        Netsh-based fallback for Ethernet detection.
+        Return active Ethernet interfaces using PowerShell as a fallback.
+
+        This path is intentionally kept out of the normal polling loop because
+        starting PowerShell every few seconds is noticeably heavier than the
+        ``netsh`` interface query.
+        """
+        output = self._run_powershell(
+            '$adapters = Get-NetAdapter -Physical | Where-Object {'
+            ' $_.InterfaceType -eq 6'
+            ' -and $_.Status -eq "Up"'
+            ' -and $_.MediaConnectionState -eq "Connected"'
+            ' -and $_.PhysicalMediaType -eq "802.3"'
+            ' -and $_.ComponentID -ne "*msloop"'
+            ' } | Select-Object Name, InterfaceDescription;'
+            ' if ($adapters) { $adapters | ConvertTo-Json -Compress } else { "[]" }'
+        )
+        parsed = json.loads(output or '[]')
+        adapters = parsed if isinstance(parsed, list) else [parsed]
+        names = [
+            str(adapter.get('Name', '')).strip()
+            for adapter in adapters
+            if self._is_probable_ethernet_name(str(adapter.get('Name', '')))
+            and self._is_probable_ethernet_name(str(adapter.get('InterfaceDescription', '')))
+        ]
+        self.logger.debug(
+            'PowerShell Ethernet candidates: %s',
+            ', '.join(names) if names else '[none]',
+        )
+        return names
+
+    def _get_active_ethernet_interfaces_netsh_strict(
+        self,
+        wifi_interface_name: str | None = None,
+    ) -> list[str]:
+        """
+        Netsh-based Ethernet detection that lets command failures propagate.
 
         Checks ``netsh interface show interface`` for any enabled, connected,
         Dedicated interface that is not a known wireless adapter and does not
@@ -746,15 +767,14 @@ class NetshWiFiApi:
         Returns:
             List of candidate Ethernet interface names.
         """
-        try:
-            output = self.run_netsh(['interface', 'show', 'interface'])
-        except NetshError:
-            return []
+        output = self.run_netsh(['interface', 'show', 'interface'])
 
         # Collect *all* wireless interface names so we can exclude them.
-        wireless_names: set[str] = self._get_all_wireless_interface_names()
+        wireless_names: set[str] = set()
         if wifi_interface_name:
             wireless_names.add(wifi_interface_name.strip().lower())
+        else:
+            wireless_names.update(self._get_all_wireless_interface_names())
 
         connected_interfaces: list[str] = []
         for line in output.splitlines():
@@ -778,6 +798,15 @@ class NetshWiFiApi:
             ', '.join(connected_interfaces) if connected_interfaces else '[none]',
         )
         return connected_interfaces
+
+    def _get_active_ethernet_interfaces_netsh(self, wifi_interface_name: str | None = None) -> list[str]:
+        """
+        Netsh-based fallback for Ethernet detection.
+        """
+        try:
+            return self._get_active_ethernet_interfaces_netsh_strict(wifi_interface_name)
+        except NetshError:
+            return []
 
     def sync_profile_order(self, interface_name: str, ssids: list[str]) -> None:
         """

--- a/src/wifi_pref_manager/netsh_wifi.py
+++ b/src/wifi_pref_manager/netsh_wifi.py
@@ -770,11 +770,9 @@ class NetshWiFiApi:
         output = self.run_netsh(['interface', 'show', 'interface'])
 
         # Collect *all* wireless interface names so we can exclude them.
-        wireless_names: set[str] = set()
+        wireless_names: set[str] = self._get_all_wireless_interface_names()
         if wifi_interface_name:
             wireless_names.add(wifi_interface_name.strip().lower())
-        else:
-            wireless_names.update(self._get_all_wireless_interface_names())
 
         connected_interfaces: list[str] = []
         for line in output.splitlines():

--- a/src/wifi_pref_manager/service.py
+++ b/src/wifi_pref_manager/service.py
@@ -117,6 +117,7 @@ class WiFiPreferenceService:
             message='Waiting for an active network connection.',
         )
         self._last_observed_ssid: str | None = None
+        self._has_observed_connection_state = False
         self._connected_ssid_since: float | None = None
         self._last_speed_test_attempt_ssid: str | None = None
         self._last_speed_test_at: float | None = None
@@ -315,6 +316,32 @@ class WiFiPreferenceService:
                 continue
             return preference.ssid
         return None
+
+    def _needs_visible_network_scan(self, current_ssid: str | None) -> bool:
+        """
+        Return whether the current state needs a visible-network scan.
+
+        ``netsh wlan show networks mode=bssid`` is one of the more expensive
+        commands in the steady-state tray loop.  When the machine is already on
+        the highest actionable preference and no signal threshold is configured
+        for that network, scanning cannot produce a different switching
+        decision, so the service can safely wait for the next cycle.
+        """
+        if current_ssid is None:
+            return True
+
+        current_index = self.preference_index(current_ssid)
+        if current_index >= len(self.config.preferred_networks):
+            return True
+
+        current_preference = self.config.preferred_networks[current_index]
+        if current_preference.min_db is not None:
+            return True
+
+        return any(
+            preference.auto_switch
+            for preference in self.config.preferred_networks[:current_index]
+        )
 
     def reload_config(self, new_config: AppConfig) -> None:
         """
@@ -971,11 +998,18 @@ class WiFiPreferenceService:
                 Optional explicit connection-change signal for immediate post-connect runs.
         """
         now = time.time()
-        observed_change = current_ssid != self._last_observed_ssid if connection_changed is None else connection_changed
+        previous_ssid = self._last_observed_ssid
+        had_observed_connection_state = self._has_observed_connection_state
+        observed_change = (
+            had_observed_connection_state and current_ssid != previous_ssid
+            if connection_changed is None
+            else connection_changed
+        )
 
-        if current_ssid != self._last_observed_ssid:
+        if not had_observed_connection_state or current_ssid != previous_ssid:
             self._connected_ssid_since = now if current_ssid is not None else None
         self._last_observed_ssid = current_ssid
+        self._has_observed_connection_state = True
 
         if not self.config.enable_speed_tests:
             return
@@ -1113,6 +1147,16 @@ class WiFiPreferenceService:
 
         current_ssid = self.wifi_api.get_current_ssid()
         self._track_current_wifi_network(current_ssid)
+
+        if not self._needs_visible_network_scan(current_ssid):
+            self.logger.debug(
+                'Skipping visible-network scan while connected to %r; no higher-priority '
+                'auto-switch network or signal threshold applies.',
+                current_ssid,
+            )
+            self._maybe_schedule_speed_test(current_ssid)
+            return
+
         visible_networks = self.wifi_api.get_visible_network_signals()
         best_available = self.best_available_ssid(visible_networks)
         current_meets_min_signal = self._network_meets_signal_requirement(current_ssid, visible_networks)

--- a/src/wifi_pref_manager/ui/dialogs.py
+++ b/src/wifi_pref_manager/ui/dialogs.py
@@ -18,6 +18,7 @@ MB_ICONWARNING = 0x00000030
 MB_ICONINFORMATION = 0x00000040
 MB_SETFOREGROUND = 0x00010000
 MB_TOPMOST = 0x00040000
+UI_QUEUE_POLL_INTERVAL_MS = 100
 
 
 class _TkUiDispatcher:
@@ -41,7 +42,7 @@ class _TkUiDispatcher:
         self._root = root
         self._owner_thread_id = threading.get_ident()
         self._ready_event.set()
-        root.after(10, self._drain_queue)
+        root.after(UI_QUEUE_POLL_INTERVAL_MS, self._drain_queue)
         root.mainloop()
 
     def _ensure_started(self) -> None:
@@ -80,7 +81,7 @@ class _TkUiDispatcher:
                 if done_event is not None:
                     done_event.set()
 
-        root.after(10, self._drain_queue)
+        root.after(UI_QUEUE_POLL_INTERVAL_MS, self._drain_queue)
 
     def call(self, callback: Callable[[tk.Tk], object], *, wait: bool) -> object | None:
         """

--- a/tests/test_netsh_wifi.py
+++ b/tests/test_netsh_wifi.py
@@ -10,28 +10,78 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'src'))
 from wifi_pref_manager.netsh_wifi import NetshError, NetshWiFiApi
 
 
+_INTERFACE_TABLE = '\n'.join(
+    [
+        'Admin State    State          Type             Interface Name',
+        '-------------------------------------------------------------------------',
+        'Enabled        Connected      Dedicated        Ethernet',
+        'Enabled        Connected      Dedicated        Wi-Fi',
+        'Enabled        Connected      Dedicated        vEthernet (Default Switch)',
+        'Enabled        Disconnected   Dedicated        Ethernet 2',
+    ]
+)
+
+_WLAN_SHOW_INTERFACES_SINGLE = 'Name                   : Wi-Fi\n'
+
+_WLAN_SHOW_INTERFACES_MULTI = (
+    'Name                   : Wi-Fi\n'
+    'Name                   : Wi-Fi 2\n'
+)
+
+
+def _make_run_netsh_side_effect(wlan_output: str):
+    """Return a side_effect callable that dispatches on the netsh sub-command."""
+
+    def _dispatch(args):
+        if args[0] == 'wlan':
+            return wlan_output
+        return _INTERFACE_TABLE
+
+    return _dispatch
+
+
 class NetshWiFiEthernetDetectionTests(unittest.TestCase):
     def test_active_ethernet_detection_uses_netsh_without_powershell_when_available(self) -> None:
         api = NetshWiFiApi(logger=Mock())
         api.run_netsh = Mock(  # type: ignore[method-assign]
-            return_value='\n'.join(
-                [
-                    'Admin State    State          Type             Interface Name',
-                    '-------------------------------------------------------------------------',
-                    'Enabled        Connected      Dedicated        Ethernet',
-                    'Enabled        Connected      Dedicated        Wi-Fi',
-                    'Enabled        Connected      Dedicated        vEthernet (Default Switch)',
-                    'Enabled        Disconnected   Dedicated        Ethernet 2',
-                ]
-            )
+            side_effect=_make_run_netsh_side_effect(_WLAN_SHOW_INTERFACES_SINGLE)
         )
         api._run_powershell = Mock(side_effect=AssertionError('PowerShell should not be used'))  # type: ignore[method-assign]
 
         result = api.get_active_ethernet_interfaces(wifi_interface_name='Wi-Fi')
 
         self.assertEqual(result, ['Ethernet'])
-        api.run_netsh.assert_called_once_with(['interface', 'show', 'interface'])
         api._run_powershell.assert_not_called()
+
+    def test_extra_wireless_adapters_excluded_when_wifi_interface_name_supplied(self) -> None:
+        """When wifi_interface_name is given, *all* WLAN adapters must still be excluded."""
+        api = NetshWiFiApi(logger=Mock())
+        api.run_netsh = Mock(  # type: ignore[method-assign]
+            side_effect=_make_run_netsh_side_effect(_WLAN_SHOW_INTERFACES_MULTI)
+        )
+        api._run_powershell = Mock(side_effect=AssertionError('PowerShell should not be used'))  # type: ignore[method-assign]
+
+        # Interface table additionally has "Wi-Fi 2" connected as Dedicated.
+        interface_table_with_extra = '\n'.join(
+            [
+                'Admin State    State          Type             Interface Name',
+                '-------------------------------------------------------------------------',
+                'Enabled        Connected      Dedicated        Ethernet',
+                'Enabled        Connected      Dedicated        Wi-Fi',
+                'Enabled        Connected      Dedicated        Wi-Fi 2',
+                'Enabled        Connected      Dedicated        vEthernet (Default Switch)',
+            ]
+        )
+        api.run_netsh = Mock(  # type: ignore[method-assign]
+            side_effect=lambda args: (
+                _WLAN_SHOW_INTERFACES_MULTI if args[0] == 'wlan' else interface_table_with_extra
+            )
+        )
+
+        result = api.get_active_ethernet_interfaces(wifi_interface_name='Wi-Fi')
+
+        # Both Wi-Fi and Wi-Fi 2 must be excluded; only Ethernet remains.
+        self.assertEqual(result, ['Ethernet'])
 
     def test_active_ethernet_detection_falls_back_to_powershell_when_netsh_fails(self) -> None:
         api = NetshWiFiApi(logger=Mock())

--- a/tests/test_netsh_wifi.py
+++ b/tests/test_netsh_wifi.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import unittest
+from unittest.mock import Mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'src'))
+
+from wifi_pref_manager.netsh_wifi import NetshError, NetshWiFiApi
+
+
+class NetshWiFiEthernetDetectionTests(unittest.TestCase):
+    def test_active_ethernet_detection_uses_netsh_without_powershell_when_available(self) -> None:
+        api = NetshWiFiApi(logger=Mock())
+        api.run_netsh = Mock(  # type: ignore[method-assign]
+            return_value='\n'.join(
+                [
+                    'Admin State    State          Type             Interface Name',
+                    '-------------------------------------------------------------------------',
+                    'Enabled        Connected      Dedicated        Ethernet',
+                    'Enabled        Connected      Dedicated        Wi-Fi',
+                    'Enabled        Connected      Dedicated        vEthernet (Default Switch)',
+                    'Enabled        Disconnected   Dedicated        Ethernet 2',
+                ]
+            )
+        )
+        api._run_powershell = Mock(side_effect=AssertionError('PowerShell should not be used'))  # type: ignore[method-assign]
+
+        result = api.get_active_ethernet_interfaces(wifi_interface_name='Wi-Fi')
+
+        self.assertEqual(result, ['Ethernet'])
+        api.run_netsh.assert_called_once_with(['interface', 'show', 'interface'])
+        api._run_powershell.assert_not_called()
+
+    def test_active_ethernet_detection_falls_back_to_powershell_when_netsh_fails(self) -> None:
+        api = NetshWiFiApi(logger=Mock())
+        api.run_netsh = Mock(side_effect=NetshError('netsh unavailable'))  # type: ignore[method-assign]
+        api._run_powershell = Mock(  # type: ignore[method-assign]
+            return_value=(
+                '[{"Name":"Ethernet","InterfaceDescription":"Intel Ethernet"},'
+                '{"Name":"vEthernet (Default Switch)","InterfaceDescription":"Hyper-V Virtual Ethernet Adapter"}]'
+            )
+        )
+
+        result = api.get_active_ethernet_interfaces(wifi_interface_name='Wi-Fi')
+
+        self.assertEqual(result, ['Ethernet'])
+        api._run_powershell.assert_called_once()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_service_switching.py
+++ b/tests/test_service_switching.py
@@ -25,6 +25,7 @@ class FakeWiFiApi:
         }
         self.disconnect_calls = 0
         self.connect_calls: list[str] = []
+        self.visible_scan_calls = 0
 
     def is_interface_enabled(self, interface_name: str) -> bool:
         del interface_name
@@ -84,6 +85,7 @@ class FakeWiFiApi:
         return True
 
     def get_visible_network_signals(self) -> dict[str, int]:
+        self.visible_scan_calls += 1
         return dict(self.visible_networks)
 
     def sync_profile_order(self, interface_name: str, ssids: list[str]) -> None:
@@ -169,6 +171,66 @@ class ServiceSwitchingThresholdTests(unittest.TestCase):
 
         self.assertEqual(api.connect_calls, ['BackupWiFi'])
         self.assertEqual(api.current_ssid, 'BackupWiFi')
+
+    def test_skips_visible_scan_when_current_network_is_already_highest_actionable(self) -> None:
+        api = FakeWiFiApi()
+        api.current_ssid = 'HomeWiFi'
+        api.visible_networks = {'BackupWiFi': -40}
+        config = AppConfig(
+            preferred_networks=[
+                WiFiProfilePreference('HomeWiFi'),
+                WiFiProfilePreference('BackupWiFi'),
+            ],
+            interface_name='Wi-Fi',
+            auto_disable_wifi_on_ethernet=False,
+            show_wifi_disabled_dialog=False,
+            enable_speed_tests=False,
+        )
+        service = WiFiPreferenceService(
+            config=config,
+            wifi_api=api,
+            logger=Mock(),
+        )
+
+        service.evaluate_and_switch()
+
+        self.assertEqual(api.visible_scan_calls, 0)
+        self.assertEqual(api.disconnect_calls, 0)
+        self.assertEqual(api.connect_calls, [])
+
+    def test_still_scans_when_current_network_has_minimum_signal_threshold(self) -> None:
+        api = FakeWiFiApi()
+        api.current_ssid = 'HomeWiFi'
+        api.visible_networks = {'HomeWiFi': -55}
+        service = self._build_service(api)
+
+        service.evaluate_and_switch()
+
+        self.assertEqual(api.visible_scan_calls, 1)
+        self.assertEqual(api.disconnect_calls, 0)
+        self.assertEqual(api.connect_calls, [])
+
+    def test_speed_test_on_new_connection_ignores_initial_observed_connection(self) -> None:
+        api = FakeWiFiApi()
+        config = AppConfig(
+            preferred_networks=[WiFiProfilePreference('HomeWiFi')],
+            interface_name='Wi-Fi',
+            auto_disable_wifi_on_ethernet=False,
+            show_wifi_disabled_dialog=False,
+            enable_speed_tests=True,
+            speed_test_on_new_connection=True,
+        )
+        service = WiFiPreferenceService(
+            config=config,
+            wifi_api=api,
+            logger=Mock(),
+        )
+        service._start_speed_test = Mock()  # type: ignore[method-assign]
+
+        service._maybe_schedule_speed_test('HomeWiFi')
+        service._maybe_schedule_speed_test('BackupWiFi')
+
+        service._start_speed_test.assert_called_once_with('BackupWiFi', 'new network connection')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description

ReadTheDocs builds were failing because `.readthedocs.yaml` sets `fail_on_warning: true` and Sphinx was emitting 23 `myst.xref_missing` warnings for every `#anchor` link in `docs/wiki/Command-Line-Interface-(CLI)-Reference.md`.

**Root cause (docs):** The doc used raw HTML `<a id="anchor-name"></a>` tags as section anchors. MyST-parser does not register these as Sphinx cross-reference targets — only `(label)=` syntax creates resolvable MyST labels.

- Replaced all 12 `<a id="X"></a>` anchors with `(X)=` MyST label syntax throughout the CLI reference

Before:
```markdown
<a id="top-level-flags"></a>

## Top-Level Flags
```

After:
```markdown
(top-level-flags)=

## Top-Level Flags
```

**Root cause (code):** In `_get_active_ethernet_interfaces_netsh_strict`, `_get_all_wireless_interface_names()` was only called when `wifi_interface_name` was falsy. When a specific Wi-Fi interface name was supplied, other wireless adapters were no longer added to the exclusion set and could be misclassified as Ethernet.

- Fixed `_get_active_ethernet_interfaces_netsh_strict` to always call `_get_all_wireless_interface_names()` first, then additionally add the explicit `wifi_interface_name` if provided — ensuring all WLAN adapters are always excluded regardless of which argument form is used.
- Updated `tests/test_netsh_wifi.py` to use `side_effect` dispatch for the two `run_netsh` calls, and added a new test verifying that a second wireless adapter (`Wi-Fi 2`) is correctly excluded when `wifi_interface_name='Wi-Fi'` is passed.

## Related issue

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactor / code quality improvement

## Testing

- RTD will re-build against the updated branch on merge (docs fix).
- `tests/test_netsh_wifi.py` updated and extended; all 3 tests pass (`poetry run pytest tests/test_netsh_wifi.py`).

- [x] I added or updated regression tests for the change
- [ ] I ran `poetry run pytest`

## Checklist

- [x] I updated documentation where applicable
- [x] I updated `CHANGELOG.md` and bumped the version in `pyproject.toml` and `src/wifi_pref_manager/__init__.py`, or this PR is docs/process only
- [ ] I kept Tk GUI changes on the shared UI thread
- [ ] I verified launcher, splash, or tray changes with targeted tests when applicable