### PR TITLE
Prepare PolyFi 1.0.0 RC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ versions so packaging, docs, and support paths stay aligned.
 
 ## [Unreleased]
 
+## [1.0.0-rc.1] - 2026-06-11
+
+### Changed
+
+- Promoted the 1.0 release train to a release candidate after stabilizing the
+  Python 3.12+ exit-state restoration dependency on `easy-exit-calls` 1.0.0.
+
+### Fixed
+
+- Added regression coverage for updater version ordering across the final
+  prerelease sequence, ensuring `1.0.0-dev.22` upgrades to `1.0.0-rc.1`,
+  release candidates upgrade to `1.0.0`, and the stable release does not report
+  itself as outdated.
+
 ## [1.0.0-dev.22] - 2026-06-09
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "polyfi-ranked"
-version = "1.0.0-dev.22"
+version = "1.0.0-rc.1"
 description = "Windows Wi-Fi preference manager that auto-switches to the highest-priority available network."
 authors = ["Inspyre Softworks"]
 readme = "README.md"
@@ -17,7 +17,7 @@ python = "^3.11"
 pystray = "^0.19.5"
 pillow = "^11.1.0"
 speedtest-cli = "^2.1.3"
-easy-exit-calls = {version = "^1.0.0.dev1", python = ">=3.12,<4.0"}
+easy-exit-calls = {version = "^1.0.0", python = ">=3.12,<4.0"}
 inspy-logger = "^3.2.3"
 platformdirs = "^4.9.4"
 

--- a/src/wifi_pref_manager/__init__.py
+++ b/src/wifi_pref_manager/__init__.py
@@ -1,4 +1,4 @@
 """PolyFi: Ranked package."""
 
 __all__ = ['__version__']
-__version__ = '1.0.0-dev.22'
+__version__ = '1.0.0-rc.1'

--- a/tests/test_updates.py
+++ b/tests/test_updates.py
@@ -45,6 +45,38 @@ class UpdateTests(unittest.TestCase):
         self.assertTrue(is_newer_version('1.0.0', '1.0.0-dev.18'))
         self.assertFalse(is_newer_version('1.0.0-dev.17', '1.0.0-dev.17'))
 
+    def test_version_comparison_handles_release_candidate_sequence(self) -> None:
+        self.assertTrue(is_newer_version('1.0.0-rc.1', '1.0.0-dev.22'))
+        self.assertTrue(is_newer_version('1.0.0', '1.0.0-rc.1'))
+        self.assertFalse(is_newer_version('1.0.0-rc.1', '1.0.0'))
+        self.assertFalse(is_newer_version('1.0.0', '1.0.0'))
+
+    def test_choose_latest_update_prefers_stable_over_release_candidate(self) -> None:
+        update = choose_latest_update(
+            [
+                {
+                    'tag_name': 'v1.0.0-rc.1',
+                    'html_url': 'https://example.invalid/releases/v1.0.0-rc.1',
+                    'assets': [],
+                },
+                {
+                    'tag_name': 'v1.0.0',
+                    'html_url': 'https://example.invalid/releases/v1.0.0',
+                    'assets': [],
+                },
+                {
+                    'tag_name': 'v1.0.0-dev.22',
+                    'html_url': 'https://example.invalid/releases/v1.0.0-dev.22',
+                    'assets': [],
+                },
+            ],
+            '1.0.0-dev.22',
+        )
+
+        self.assertIsNotNone(update)
+        assert update is not None
+        self.assertEqual(update.version, '1.0.0')
+
     def test_select_windows_installer_prefers_setup_exe(self) -> None:
         asset = select_windows_installer_asset(
             [


### PR DESCRIPTION
## Description

Prepare the PolyFi: Ranked 1.0.0 release candidate.

- Bump PolyFi metadata to `1.0.0-rc.1`.
- Move the Python 3.12+ exit-state restoration dependency to stable `easy-exit-calls` `^1.0.0`.
- Add changelog coverage for the RC.
- Add updater regression tests for `1.0.0-dev.22 -> 1.0.0-rc.1 -> 1.0.0` ordering.

## Testing

- `poetry install --with dev --no-interaction`
- `poetry run pytest -q` (`177 passed`)
- `poetry install --with docs --no-interaction`
- `poetry run sphinx-build -W -b html docs docs/_build/local-html`
- `poetry install --with packaging --no-interaction`
- `powershell -ExecutionPolicy Bypass -File .\scripts\build_windows_installer.ps1` reached a successful PyInstaller bundle build, then failed because local `ISCC.exe` / Inno Setup is not installed.
- `poetry build`
- PE subsystem check: `polyfi-ranked.exe` is Windows GUI and `polyfi-ranked-console.exe` is Windows CUI.

## Notes

`poetry.lock` is present locally but is not tracked in this repository. `poetry install` updated the environment from `easy-exit-calls 1.0.0.dev1` to `1.0.0` after the stable dependency was published to PyPI.

## Summary by Sourcery

Prepare the PolyFi: Ranked 1.0.0 release candidate and align metadata, dependencies, and tests with the new version.

Bug Fixes:
- Ensure updater version ordering correctly handles the 1.0.0-dev.22 → 1.0.0-rc.1 → 1.0.0 sequence and does not treat stable releases as outdated.

Enhancements:
- Promote project version metadata to 1.0.0-rc.1 and update the package __version__ accordingly.
- Move the Python 3.12+ exit-state restoration dependency to the stable easy-exit-calls 1.0.0 release.

Documentation:
- Add changelog entry documenting the 1.0.0-rc.1 release candidate and its updater behavior coverage.

Tests:
- Add regression tests for version comparison and update selection to cover release candidate versus dev and stable releases.